### PR TITLE
Set Blocks relation when generating block

### DIFF
--- a/fireball/src/core/block.rs
+++ b/fireball/src/core/block.rs
@@ -17,10 +17,10 @@ pub struct Block {
     start_address: Address,
     /// 블럭의 마지막 인스트럭션의 주소
     end_address: Option<Address>,
-    /// 현재 블럭과 연관되어있는 블럭들을 담은 벡터
+    /// 현재 블럭과 연관되어있는 블럭
     connected_from: RwLock<Vec<Relation>>,
     /// 현재 블럭과 연관된 블럭
-    connected_to: RwLock<Option<Relation>>,
+    connected_to: RwLock<Vec<Relation>>,
     /// 블럭의 섹션
     section: Option<Arc<Section>>,
 }
@@ -102,9 +102,9 @@ impl Block {
     /// 해당 블럭이 어떤 블럭으로 연결되어있는지를 반환한다.
     ///
     /// ### Returns
-    /// - `Option<Relation>` - 연결된 블럭
-    pub fn get_connected_to(&self) -> Option<Relation> {
-        *self.connected_to.read().unwrap()
+    /// - `RwLockReadGuard<Vec<Relation>>` - 연결된 블럭들
+    pub fn get_connected_to(&self) -> RwLockReadGuard<Vec<Relation>> {
+        self.connected_to.read().unwrap()
     }
 
     /// 블럭이 어떤 섹션에 해당하는지를 반환한다.
@@ -123,12 +123,12 @@ impl Block {
         self.connected_from.write().unwrap().push(relation);
     }
 
-    /// 해당 블럭이 어떤 블럭에 연결되어 있는지를 지정한다.
+    /// 해당 블럭이 어떤 블럭에 연결되어 있는지를 추가한다.
     ///
     /// ### Arguments
     /// - `relation: Relation` - 해당 블럭이 향하는 블럭
-    pub(crate) fn set_connected_to(&self, relation: Relation) {
-        *self.connected_to.write().unwrap() = Some(relation);
+    pub(crate) fn add_connected_to(&self, relation: Relation) {
+        self.connected_to.write().unwrap().push(relation);
     }
 }
 

--- a/fireball/src/core/block.rs
+++ b/fireball/src/core/block.rs
@@ -129,6 +129,10 @@ impl Block {
     /// - `relation: Relation` - 해당 블럭이 향하는 블럭
     pub(crate) fn add_connected_to(&self, relation: Relation) {
         self.connected_to.write().unwrap().push(relation);
+        debug_assert!(
+            self.connected_to.read().unwrap().len() <= 2,
+            "한 블럭에는 최대 두 개의 블럭이 연결될 수 있습니다."
+        );
     }
 }
 

--- a/fireball/src/core/blocks.rs
+++ b/fireball/src/core/blocks.rs
@@ -45,15 +45,14 @@ impl Blocks {
                 .read()
                 .unwrap()
                 .iter()
-                .map(|block| block.get_connected_to().clone())
-                .flatten()
+                .flat_map(|block| block.get_connected_to().clone())
                 .filter(|relation| relation.to().as_ref() == Some(&start_address))
                 .collect()
         };
 
         /* 락 해제 전 관계 생성 (관계 생성중 저장소 접근 필요하기 떄문) */
         let connected_to: Vec<_> = connected_to
-            .into_iter()
+            .iter()
             .map(|connected_to| {
                 let connected_block = connected_to
                     .0

--- a/fireball/src/core/mod.rs
+++ b/fireball/src/core/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use instruction::Instruction;
 pub use instruction_history::InstructionHistory;
 pub use pre_defined_offset::PreDefinedOffset;
 pub use pre_defined_offsets::PreDefinedOffsets;
-pub use relation::{Relation, RelationType};
+pub use relation::{DestinationType, Relation, RelationType};
 pub use relations::Relations;
 pub use section::Section;
 pub use sections::Sections;

--- a/fireball/src/core/relation.rs
+++ b/fireball/src/core/relation.rs
@@ -7,8 +7,18 @@ pub struct Relation {
     from: usize,
     /// 해당 연결의 도착 블럭 아이디
     to: Option<usize>,
+    /// 해당 연결의 도착 주소 타입
+    destination_type: DestinationType,
     /// 해당 연결의 타입
     relation_type: RelationType,
+}
+
+#[derive(Debug, Eq, Hash, PartialEq, Clone, Copy)]
+pub enum DestinationType {
+    /// 정적 주소
+    Static,
+    /// 동적 주소
+    Dynamic,
 }
 
 /// 코드 블럭의 연결 타입을 나타낸다.
@@ -21,8 +31,8 @@ pub enum RelationType {
     Jcc,
     /// 한 블럭이 여러 블럭으로 나누어 진 경우
     Continued,
-    /// 오프셋에 의해 연결 타겟이 달라지는 경우
-    Dynamic,
+    /// 해당 연결이 ret 연결임을 나타낸다.
+    Return,
 }
 
 impl Relation {
@@ -31,14 +41,21 @@ impl Relation {
     /// ### Arguments
     /// - `from: usize`: 연결의 출발 블럭 아이디
     /// - `to: Option<usize>`: 연결의 도착 블럭 아이디
+    /// - `destination_type: DestinationType`: 연결의 도착 주소 타입
     /// - `relation_type: RelationType`: 연결의 타입
     ///
     /// ### Returns
     /// - `Self`: 새로 생성된 연결
-    pub fn new(from: usize, to: Option<usize>, relation_type: RelationType) -> Self {
+    pub fn new(
+        from: usize,
+        to: Option<usize>,
+        destination_type: DestinationType,
+        relation_type: RelationType,
+    ) -> Self {
         Self {
             from,
             to,
+            destination_type,
             relation_type,
         }
     }

--- a/fireball/src/core/relation.rs
+++ b/fireball/src/core/relation.rs
@@ -1,12 +1,14 @@
 //! 분석중 나온 분기에 대한 연관관계를 정의하는 모듈
 
+use crate::core::Address;
+
 /// 코드 블럭과 다른 블럭과의 연결을 나타낸다. (jmp, call 등)
-#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct Relation {
     /// 해당 연결의 출발 블럭 아이디
     from: usize,
-    /// 해당 연결의 도착 블럭 아이디
-    to: Option<usize>,
+    /// 해당 연결의 도착 주소
+    to: Option<Address>,
     /// 해당 연결의 도착 주소 타입
     destination_type: DestinationType,
     /// 해당 연결의 타입
@@ -40,7 +42,7 @@ impl Relation {
     ///
     /// ### Arguments
     /// - `from: usize`: 연결의 출발 블럭 아이디
-    /// - `to: Option<usize>`: 연결의 도착 블럭 아이디
+    /// - `to: Option<Address>`: 연결의 도착 주소
     /// - `destination_type: DestinationType`: 연결의 도착 주소 타입
     /// - `relation_type: RelationType`: 연결의 타입
     ///
@@ -48,7 +50,7 @@ impl Relation {
     /// - `Self`: 새로 생성된 연결
     pub fn new(
         from: usize,
-        to: Option<usize>,
+        to: Option<Address>,
         destination_type: DestinationType,
         relation_type: RelationType,
     ) -> Self {
@@ -71,9 +73,9 @@ impl Relation {
     /// 연결의 도착 블럭을 가져온다.
     ///
     /// ### Returns
-    /// - `Option<usize>`: 연결의 도착 블럭 아이디
-    pub fn to(&self) -> Option<usize> {
-        self.to
+    /// - `Option<Address>`: 연결의 도착 주소
+    pub fn to(&self) -> Option<Address> {
+        self.to.clone()
     }
 
     pub fn relation_type(&self) -> &RelationType {

--- a/fireball/src/pe/_pe.rs
+++ b/fireball/src/pe/_pe.rs
@@ -1,7 +1,7 @@
 //! PE 구조체에 대한 구현이 담겨있는 모듈
 
 use super::PE;
-use crate::core::{Address, Blocks, PreDefinedOffset, PreDefinedOffsets, Relations, Sections};
+use crate::core::{Address, Blocks, PreDefinedOffset, PreDefinedOffsets, Sections};
 use capstone::prelude::BuildsCapstone;
 
 impl PE {
@@ -77,7 +77,6 @@ impl PE {
             capstone,
             defined,
             sections,
-            relations: Relations::new(),
             blocks: Blocks::new(),
         }
     }

--- a/fireball/src/pe/_pe.rs
+++ b/fireball/src/pe/_pe.rs
@@ -80,4 +80,9 @@ impl PE {
             blocks: Blocks::new(),
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn inspect_blocks(&self) -> std::sync::Arc<Blocks> {
+        self.blocks.clone()
+    }
 }

--- a/fireball/src/pe/block.rs
+++ b/fireball/src/pe/block.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Address, Block},
+    core::{Address, Block, DestinationType, RelationType},
     pe::PE,
 };
 use std::sync::Arc;
@@ -36,6 +36,173 @@ impl PE {
             address += inst.bytes.as_ref().unwrap().len() as u64;
         }
 
-        self.blocks.generate_block(start_address, end_address, None)
+        /* 해당 블럭에서 연결된 다른 블럭 찾기 */
+        let mut connected_to = Vec::new();
+        // 끝 주소가 정해지지 않은 경우 연결된 블럭 없음
+        if let Some(end_address) = &end_address {
+            let inst = &self.parse_assem_count(end_address, 1).unwrap()[0].inner;
+            // 다음 주소
+            connected_to.push((
+                Some(end_address + inst.bytes.as_ref().unwrap().len() as u64),
+                DestinationType::Static,
+                RelationType::Continued,
+            ));
+            // jcc나 call등에 의해 이동하는 주소
+            connected_to.push(self.get_connected_address_and_relation_type(end_address, inst));
+        }
+
+        self.blocks
+            .generate_block(start_address, end_address, &connected_to, None)
+    }
+
+    /// 마지막 인스트럭션을 통해 어떤 주소와 연결되어있는지 파악한다
+    fn get_connected_address_and_relation_type(
+        &self,
+        ip: &Address,
+        inst: &iceball::Instruction,
+    ) -> (Option<Address>, DestinationType, RelationType) {
+        let relation_type = match () {
+            _ if inst.is_ret() => RelationType::Return,
+            _ if inst.is_jcc() => RelationType::Jcc,
+            _ if inst.is_call() => RelationType::Call,
+            _ => unreachable!("{:?}", inst),
+        };
+        if inst.arguments.len() != 1 {
+            return (None, DestinationType::Dynamic, relation_type);
+        }
+        let arg = &inst.arguments[0];
+        return match arg {
+            // only rip is predictable target but we can't get it
+            iceball::Argument::Register(_) => (None, DestinationType::Dynamic, relation_type),
+            iceball::Argument::Memory(iceball::Memory::AbsoluteAddressing(offset)) => (
+                Some(Address::from_virtual_address(&self.sections, *offset)),
+                DestinationType::Static,
+                relation_type,
+            ),
+            iceball::Argument::Memory(iceball::Memory::RelativeAddressing(args)) => {
+                if args
+                    .iter()
+                    .filter(|x| matches!(x, iceball::RelativeAddressingArgument::Register(_)))
+                    .all(|x| {
+                        matches!(
+                            x,
+                            iceball::RelativeAddressingArgument::Register(iceball::Register::X64(
+                                iceball::X64Register::Eip,
+                            )) | iceball::RelativeAddressingArgument::Register(
+                                iceball::Register::X64(iceball::X64Register::Rip,)
+                            )
+                        )
+                    })
+                {
+                    (
+                        Some(self.calc_relative_address_with_ip(ip, args)),
+                        DestinationType::Static,
+                        relation_type,
+                    )
+                } else {
+                    (None, DestinationType::Dynamic, relation_type)
+                }
+            }
+            iceball::Argument::Constant(_) => unreachable!("{:?}", arg),
+        };
+    }
+    fn calc_relative_address_with_ip(
+        &self,
+        ip: &Address,
+        args: &[iceball::RelativeAddressingArgument],
+    ) -> Address {
+        let extract_constant = |arg: &iceball::RelativeAddressingArgument| match arg {
+            iceball::RelativeAddressingArgument::Constant(x) => *x,
+            _ => unreachable!("{:?}", arg),
+        };
+        let mut args: Vec<_> = args.into();
+
+        // turn ip to constant
+        for i in &mut args {
+            match i {
+                iceball::RelativeAddressingArgument::Register(iceball::Register::X64(
+                    iceball::X64Register::Eip,
+                ))
+                | iceball::RelativeAddressingArgument::Register(iceball::Register::X64(
+                    iceball::X64Register::Rip,
+                )) => {
+                    *i = iceball::RelativeAddressingArgument::Constant(
+                        ip.get_virtual_address() as i128
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        // calc mul operator
+        while args.contains(&iceball::RelativeAddressingArgument::Operator(
+            iceball::AddressingOperator::Mul,
+        )) {
+            let operator_index = args
+                .iter()
+                .position(|x| {
+                    matches!(
+                        x,
+                        iceball::RelativeAddressingArgument::Operator(
+                            iceball::AddressingOperator::Mul
+                        )
+                    )
+                })
+                .unwrap();
+            let arg1 = extract_constant(&args[operator_index - 1]);
+            let arg2 = extract_constant(&args[operator_index + 1]);
+            args.remove(operator_index - 1);
+            args.remove(operator_index - 1);
+            args.insert(
+                operator_index - 1,
+                iceball::RelativeAddressingArgument::Constant(arg1 * arg2),
+            );
+        }
+
+        // calc add/sub operator
+        while args.contains(&iceball::RelativeAddressingArgument::Operator(
+            iceball::AddressingOperator::Add,
+        )) || args.contains(&iceball::RelativeAddressingArgument::Operator(
+            iceball::AddressingOperator::Sub,
+        )) {
+            let operator_index = args
+                .iter()
+                .position(|x| {
+                    matches!(
+                        x,
+                        iceball::RelativeAddressingArgument::Operator(
+                            iceball::AddressingOperator::Add | iceball::AddressingOperator::Sub
+                        )
+                    )
+                })
+                .unwrap();
+            let arg1 = extract_constant(&args[operator_index - 1]);
+            let arg2 = extract_constant(&args[operator_index + 1]);
+            args.remove(operator_index - 1);
+            args.remove(operator_index - 1);
+            args.insert(
+                operator_index - 1,
+                iceball::RelativeAddressingArgument::Constant(match args[operator_index - 1] {
+                    iceball::RelativeAddressingArgument::Operator(
+                        iceball::AddressingOperator::Add,
+                    ) => arg1 + arg2,
+                    iceball::RelativeAddressingArgument::Operator(
+                        iceball::AddressingOperator::Sub,
+                    ) => arg1 - arg2,
+                    _ => unreachable!(),
+                }),
+            );
+        }
+
+        // return
+        debug_assert!(
+            args.len() == 1,
+            "주소 계산이 완전하게 끝나지 않았습니다. {:?}",
+            args
+        );
+        let address = extract_constant(&args[0])
+            .try_into()
+            .expect("주소 연산 결과가 음수값입니다.");
+        Address::from_virtual_address(&self.sections, address)
     }
 }

--- a/fireball/src/pe/block.rs
+++ b/fireball/src/pe/block.rs
@@ -73,7 +73,7 @@ impl PE {
             return (None, DestinationType::Dynamic, relation_type);
         }
         let arg = &inst.arguments[0];
-        return match arg {
+        match arg {
             // only rip is predictable target but we can't get it
             iceball::Argument::Register(_) => (None, DestinationType::Dynamic, relation_type),
             iceball::Argument::Memory(iceball::Memory::AbsoluteAddressing(offset)) => (
@@ -110,7 +110,7 @@ impl PE {
                 DestinationType::Static,
                 relation_type,
             ),
-        };
+        }
     }
     fn calc_relative_address_with_ip(
         &self,

--- a/fireball/src/pe/block.rs
+++ b/fireball/src/pe/block.rs
@@ -103,7 +103,11 @@ impl PE {
                     (None, DestinationType::Dynamic, relation_type)
                 }
             }
-            iceball::Argument::Constant(_) => unreachable!("{:?}", arg),
+            iceball::Argument::Constant(arg) => (
+                Some(Address::from_virtual_address(&self.sections, *arg)),
+                DestinationType::Static,
+                relation_type,
+            ),
         };
     }
     fn calc_relative_address_with_ip(

--- a/fireball/src/pe/block.rs
+++ b/fireball/src/pe/block.rs
@@ -41,12 +41,14 @@ impl PE {
         // 끝 주소가 정해지지 않은 경우 연결된 블럭 없음
         if let Some(end_address) = &end_address {
             let inst = &self.parse_assem_count(end_address, 1).unwrap()[0].inner;
-            // 다음 주소
-            connected_to.push((
-                Some(end_address + inst.bytes.as_ref().unwrap().len() as u64),
-                DestinationType::Static,
-                RelationType::Continued,
-            ));
+            if inst.is_jcc() {
+                // 다음 주소
+                connected_to.push((
+                    Some(end_address + inst.bytes.as_ref().unwrap().len() as u64),
+                    DestinationType::Static,
+                    RelationType::Continued,
+                ));
+            }
             // jcc나 call등에 의해 이동하는 주소
             connected_to.push(self.get_connected_address_and_relation_type(end_address, inst));
         }

--- a/fireball/src/pe/block.rs
+++ b/fireball/src/pe/block.rs
@@ -13,7 +13,7 @@ impl PE {
     /// ### Returns
     /// - `Arc<Block>` - 해당 주소로부터 계산된 블럭
     pub(crate) fn generate_block_from_address(&self, address: &Address) -> Arc<Block> {
-        if let Some(block) = self.blocks.find_from_start_address(address) {
+        if let Some(block) = self.blocks.get_by_start_address(address) {
             return block;
         }
         let mut address = address.clone();

--- a/fireball/src/pe/mod.rs
+++ b/fireball/src/pe/mod.rs
@@ -6,7 +6,7 @@ mod block;
 mod fire;
 mod fmt;
 
-use crate::core::{Blocks, PreDefinedOffsets, Relations, Sections};
+use crate::core::{Blocks, PreDefinedOffsets, Sections};
 use std::{pin::Pin, sync::Arc};
 
 /// PE파일 파서
@@ -22,8 +22,6 @@ pub struct PE {
     defined: Arc<PreDefinedOffsets>,
     /// 섹션에 대한 정보를 담고 있는 데이터
     sections: Arc<Sections>,
-    /// 여러 섹션에 대한 연관 정보를 담고 있는 데이터
-    relations: Arc<Relations>,
     /// 블럭에 대한 정보를 담고 있는 데이터
     blocks: Arc<Blocks>,
 }

--- a/fireball/src/tests/pe_hello_world.rs
+++ b/fireball/src/tests/pe_hello_world.rs
@@ -93,3 +93,21 @@ fn pe_hello_world_detect_block_etc() {
         assert_ne!(*block.get_end_address().unwrap(), address);
     }
 }
+
+#[test]
+fn pe_hello_world_block_relation() {
+    test_init();
+    let binary = get_binary();
+    let pe = PE::from_binary(binary.to_vec()).unwrap();
+    let gl = goblin::pe::PE::parse(binary).unwrap();
+    let sections = pe.get_sections();
+    let entry = Address::from_virtual_address(&sections, gl.entry as u64);
+    pe.generate_block_from_address(&entry);
+    let blocks = pe.inspect_blocks();
+
+    let entry_block = blocks.get_by_start_address(&entry);
+    assert!(entry_block.is_some());
+    let entry_block = entry_block.unwrap();
+    let entry_connected_to = entry_block.get_connected_to();
+    dbg!(entry_connected_to);
+}

--- a/fireball/src/tests/pe_hello_world.rs
+++ b/fireball/src/tests/pe_hello_world.rs
@@ -109,6 +109,7 @@ fn pe_hello_world_block_relation() {
     let entry_block = blocks.get_by_start_address(&entry);
     assert!(entry_block.is_some());
     let entry_block = entry_block.unwrap();
+    let entry_block_id = entry_block.get_id();
     let entry_connected_to = entry_block.get_connected_to();
     assert_eq!(entry_connected_to.len(), 1);
     assert_eq!(entry_connected_to[0].relation_type(), &RelationType::Call);
@@ -120,6 +121,11 @@ fn pe_hello_world_block_relation() {
     let to_block = blocks.get_by_start_address(&to_address);
     assert!(to_block.is_some());
     let to_block = to_block.unwrap();
+    // check connected from
+    let to_connected_from = to_block.get_connected_from();
+    assert_eq!(to_connected_from.len(), 1);
+    assert_eq!(to_connected_from[0].from(), entry_block_id);
+    // check connected to
     let to_connected_to = to_block.get_connected_to();
     assert_eq!(to_connected_to.len(), 1);
     assert_eq!(

--- a/iceball/src/lib.rs
+++ b/iceball/src/lib.rs
@@ -48,7 +48,7 @@ pub enum Memory {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum RelativeAddressingArgument {
     Register(Register),
-    Constant(u64),
+    Constant(i128),
     Operator(AddressingOperator),
 }
 

--- a/iceball/src/x64.rs
+++ b/iceball/src/x64.rs
@@ -47,7 +47,7 @@ fn parse_memory(op: &str) -> Result<crate::Argument, crate::DisassembleError> {
             } else {
                 item.parse().unwrap()
             };
-            result.push(crate::RelativeAddressingArgument::Constant(num));
+            result.push(crate::RelativeAddressingArgument::Constant(num as i128));
             continue;
         }
 


### PR DESCRIPTION
## Summary

- change relation field

## Details

- change relation field
  because blocks created earlier cannot reference blocks created later, so relation's `to` field was change to address based field from pointing block id, 
