### PR TITLE
Turn `Block::end_address` to `Block::block_size`

### DIFF
--- a/fireball/src/core/block.rs
+++ b/fireball/src/core/block.rs
@@ -16,8 +16,8 @@ pub struct Block {
     name: Option<String>,
     /// 블럭의 시작 주소
     start_address: Address,
-    /// 블럭의 마지막 인스트럭션의 주소
-    end_address: Option<Address>,
+    /// 블럭의 사이즈
+    block_size: Option<u64>,
     /// 현재 블럭과 연관되어있는 블럭
     connected_from: RwLock<Vec<Relation>>,
     /// 현재 블럭과 연관된 블럭
@@ -38,7 +38,7 @@ impl Block {
     /// - `id: usize` - 블럭의 아이디
     /// - `name: Option<String>` - 블럭의 이름
     /// - `start_address: Address` - 블럭의 시작주소
-    /// - `end_address: Option<Address>` - 블럭의 마지막 인스트럭션의 주소
+    /// - `block_size: Option<u64>,` - 블럭의 사이즈
     ///
     /// ### Returns
     /// - `Arc<Self>` - 생성된 블럭
@@ -50,14 +50,14 @@ impl Block {
         id: usize,
         name: Option<String>,
         start_address: Address,
-        end_address: Option<Address>,
+        block_size: Option<u64>,
     ) -> Arc<Self> {
         let section = start_address.get_section();
         Arc::new(Self {
             id,
             name,
             start_address,
-            end_address,
+            block_size,
             connected_from: Default::default(),
             connected_to: Default::default(),
             section,
@@ -89,12 +89,12 @@ impl Block {
         &self.start_address
     }
 
-    /// 블럭의 끝 주소를 반환한다.
+    /// 블럭의 사이즈를 반환한다.
     ///
     /// ### Returns
-    /// - `Option<&Address>` - 블럭의 끝 주소
-    pub fn get_end_address(&self) -> Option<&Address> {
-        self.end_address.as_ref()
+    /// - `Option<&u64>` - 블럭의 사이즈
+    pub fn get_block_size(&self) -> Option<&u64> {
+        self.block_size.as_ref()
     }
 
     /// 어떤 블럭이 해당 블럭에서 연결되어있는지를 반환한다.

--- a/fireball/src/pe/fire/decom_block.rs
+++ b/fireball/src/pe/fire/decom_block.rs
@@ -13,9 +13,8 @@ impl Pe {
         // 블럭 생성
         let block = self.generate_block_from_address(address);
         // 해당 블럭의 인스트럭션 파싱
-        let end_address = block.get_end_address();
-        let block_size = if let Some(end_address) = end_address {
-            end_address - address
+        let block_size = if let Some(block_size) = block.get_block_size() {
+            *block_size
         } else {
             warn!(?address, "디컴파일 대상의 종료 위치를 찾을 수 없음");
             1

--- a/fireball/src/tests/pe_hello_world.rs
+++ b/fireball/src/tests/pe_hello_world.rs
@@ -78,7 +78,7 @@ fn pe_hello_world_detect_block_entry() {
 
     assert_eq!(&block.get_section().unwrap().name, ".text");
     assert_eq!(block.get_start_address(), entry);
-    assert_ne!(block.get_block_size(), Some(&0));
+    assert_eq!(block.get_block_size(), Some(&33)); // verified with debugger
 }
 
 #[test]

--- a/fireball/src/tests/pe_hello_world.rs
+++ b/fireball/src/tests/pe_hello_world.rs
@@ -78,7 +78,7 @@ fn pe_hello_world_detect_block_entry() {
 
     assert_eq!(&block.get_section().unwrap().name, ".text");
     assert_eq!(block.get_start_address(), entry);
-    assert_ne!(block.get_end_address().unwrap(), entry);
+    assert_ne!(block.get_block_size(), Some(&0));
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn pe_hello_world_detect_block_etc() {
         let block = pe.generate_block_from_address(&address);
         assert_eq!(&block.get_section().unwrap().name, ".text");
         assert_eq!(*block.get_start_address(), address);
-        assert_ne!(*block.get_end_address().unwrap(), address);
+        assert_ne!(block.get_block_size(), Some(&0));
     }
 }
 


### PR DESCRIPTION
## Summary

- Turn `Block::end_address` to `Block::block_size` because of ambiguity method name meanings
  this causes error when parsing assembly in block parsing

Closes #42 