### PR TITLE
feat: 자유자재로 dragging 가능하게 정리

### DIFF
--- a/firebat/src/App.tsx
+++ b/firebat/src/App.tsx
@@ -1,34 +1,47 @@
-import React, { useState } from "react";
-import logoBackgrounded from "./assets/logo colored 512.png";
+import React, { useMemo, useState } from "react";
 import "./App.css";
 import Navigation from "./Navigation";
 import LogBar from "./LogBar";
-import { closestCenter, DndContext, DragEndEvent, DragOverlay, DragStartEvent, KeyboardSensor, PointerSensor, UniqueIdentifier, useSensor, useSensors } from "@dnd-kit/core";
-import { arrayMove, horizontalListSortingStrategy, SortableContext, sortableKeyboardCoordinates, useSortable } from "@dnd-kit/sortable";
+import {
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  UniqueIdentifier,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  horizontalListSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from "@dnd-kit/sortable";
 import { PanelGroup, Panel, PanelResizeHandle } from "react-resizable-panels";
-import { CSS } from '@dnd-kit/utilities';
+import { CSS } from "@dnd-kit/utilities";
 import AssemblyPanel from "./AssemblyPanel";
 import IRPanel from "./IRPanel";
 import ASTPanel from "./ASTPanel";
 import SectionPanel from "./SectionPanel";
 
-
-interface Panel {
+// ---- Types ----
+interface PanelItem {
   id: string;
   content: React.ReactNode;
 }
+type ContainerId = "top" | "bottom";
 
-function SortablePanel({ id, content }: Readonly<Panel>) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id });
+// ---- Sortable Panel (개별 패널 카드) ----
+function SortablePanel({ id, content }: Readonly<PanelItem>) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id });
 
-  const style = {
+  const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
     zIndex: isDragging ? 10 : 1,
@@ -45,7 +58,7 @@ function SortablePanel({ id, content }: Readonly<Panel>) {
         {...attributes}
         {...listeners}
         className="h-4 w-full bg-gray-500 cursor-grab rounded-t-lg flex-shrink-0 z-10"
-      ></div>
+      />
       <div className="flex-1 bg-gray-900/20 rounded-b-lg overflow-hidden">
         {content}
       </div>
@@ -53,26 +66,102 @@ function SortablePanel({ id, content }: Readonly<Panel>) {
   );
 }
 
+
+function DroppableRow({
+  id,
+  children,
+}: {
+  id: ContainerId;
+  children: React.ReactNode;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`h-full w-full ${isOver ? "outline outline-2 outline-blue-400" : ""}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+
+function SortableRow({
+  id,
+  items,
+}: {
+  id: ContainerId;
+  items: PanelItem[];
+}) {
+  return (
+    <DroppableRow id={id}>
+      <SortableContext
+        // 같은 줄에서는 가로 정렬 전략
+        items={items.map((i) => i.id)}
+        strategy={horizontalListSortingStrategy}
+      >
+        <PanelGroup direction="horizontal" className="w-full h-full">
+          {items.length === 0 ? (null) : (
+            items.map((item, index) => (
+              <React.Fragment key={item.id}>
+                <Panel defaultSize={100 / items.length} className="h-full">
+                  <SortablePanel id={item.id} content={item.content} />
+                </Panel>
+                {index < items.length - 1 && (
+                  <PanelResizeHandle className="w-1 bg-gray-300 hover:bg-blue-500 transition-colors duration-200 cursor-ew-resize flex items-center justify-center">
+                    <div className="w-1 h-10 bg-gray-500 rounded-full" />
+                  </PanelResizeHandle>
+                )}
+              </React.Fragment>
+            ))
+          )}
+        </PanelGroup>
+      </SortableContext>
+    </DroppableRow>
+  );
+}
+
 function App() {
-  const [panels, setPanels] = useState<Panel[]>([
-    { id: 'section-panel', content: <SectionPanel /> },
-    { id: 'asm-panel', content: <AssemblyPanel /> },
-    { id: 'ir-panel', content: <IRPanel /> },
-    { id: 'ast-panel', content: <ASTPanel /> },
-  ]);
+  // 초기 4패널 정의
+  const allPanels = useMemo<PanelItem[]>(
+    () => [
+      { id: "section-panel", content: <SectionPanel /> },
+      { id: "asm-panel", content: <AssemblyPanel /> },
+      { id: "ir-panel", content: <IRPanel /> },
+      { id: "ast-panel", content: <ASTPanel /> },
+    ],
+    []
+  );
+
+  // 위/아래 두 줄 레이아웃 상태
+  const [layout, setLayout] = useState<Record<ContainerId, PanelItem[]>>({
+    top: [allPanels[0], allPanels[1]],    // 위 줄: 2개
+    bottom: [allPanels[2], allPanels[3]], // 아래 줄: 2개
+  });
+
   const [draggingPanelId, setDraggingPanelId] = useState<UniqueIdentifier | null>(null);
 
-  // dragging state
+  // dnd sensors
   const sensors = useSensors(
     useSensor(PointerSensor),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
+
+  // 유틸: 아이템이 속한 컨테이너 찾기
+  const findContainer = (id: UniqueIdentifier): ContainerId | null => {
+    if (layout.top.some((p) => p.id === id)) return "top";
+    if (layout.bottom.some((p) => p.id === id)) return "bottom";
+    return null;
+  };
+
+  // 유틸: 아이템 객체 찾기
+  const getItem = (id: UniqueIdentifier) =>
+    layout.top.find((p) => p.id === id) ?? layout.bottom.find((p) => p.id === id) ?? null;
 
   const handleDragStart = (event: DragStartEvent) => {
     setDraggingPanelId(event.active.id);
   };
+
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over) {
@@ -80,64 +169,97 @@ function App() {
       return;
     }
 
-    if (active.id !== over.id) {
-      setPanels((items) => {
-        const oldIndex = items.findIndex((item) => item.id === active.id);
-        const newIndex = items.findIndex((item) => item.id === over.id);
-        return arrayMove(items, oldIndex, newIndex);
+    const activeId = active.id;
+    const overId = over.id;
+
+    const activeContainer = findContainer(activeId);
+    const overContainer =
+      (overId === "top" || overId === "bottom") ? (overId as ContainerId) : findContainer(overId);
+
+    if (!activeContainer || !overContainer) {
+      setDraggingPanelId(null);
+      return;
+    }
+
+    // 같은 줄에서 위치만 변경
+    if (activeContainer === overContainer) {
+      if (activeId !== overId) {
+        setLayout((prev) => {
+          const items = prev[activeContainer];
+          const oldIndex = items.findIndex((i) => i.id === activeId);
+          const newIndex = items.findIndex((i) => i.id === overId);
+          const next = arrayMove(items, oldIndex, newIndex);
+          return { ...prev, [activeContainer]: next };
+        });
+      }
+    } else {
+      // 다른 줄로 이동 (상/하 이동)
+      setLayout((prev) => {
+        const fromItems = [...prev[activeContainer]];
+        const toItems = [...prev[overContainer]];
+
+        const moving = fromItems.find((i) => i.id === activeId);
+        if (!moving) return prev;
+
+        // from에서 제거
+        const fromIndex = fromItems.findIndex((i) => i.id === activeId);
+        fromItems.splice(fromIndex, 1);
+
+        // to에 삽입 위치 계산
+        const overIndex =
+          overId === overContainer
+            ? toItems.length // 빈 영역이나 줄 자체에 떨어뜨렸을 때는 맨 뒤
+            : Math.max(0, toItems.findIndex((i) => i.id === overId));
+
+        toItems.splice(overIndex, 0, moving);
+
+        return {
+          ...prev,
+          [activeContainer]: fromItems,
+          [overContainer]: toItems,
+        };
       });
     }
-    setDraggingPanelId(null);
-  };
-  const handleDragCancel = () => {
+
     setDraggingPanelId(null);
   };
 
-  const draggingPanel = draggingPanelId ? panels.find((panel) => panel.id === draggingPanelId) : null;
+  const handleDragCancel = () => setDraggingPanelId(null);
+
+  const draggingPanel = draggingPanelId ? getItem(draggingPanelId) : null;
 
   return (
     <main className="h-screen overflow-hidden flex flex-col">
       <div className="relative z-50">
         <Navigation />
-      </div>{/* <div className="row">
-        <img src="/logo transparent.svg" className="logo" alt="transparent logo" />
-        <img src={logoBackgrounded} className="logo" alt="backgrounded logo" />
-      </div> */}
+      </div>
+
       <div className="flex-1 flex items-center justify-center p-4 text-black overflow-hidden">
-        <DndContext sensors={sensors}
+        <DndContext
+          sensors={sensors}
           collisionDetection={closestCenter}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
-          onDragCancel={handleDragCancel}>
-          <SortableContext
-            items={panels.map((p) => p.id)}
-            strategy={horizontalListSortingStrategy}
-          >
-            <PanelGroup direction="horizontal" className="w-full h-full">
-              {panels.map((content, index) => (
-                <React.Fragment key={content.id}>
-                  <Panel defaultSize={100 / panels.length} className="h-full">
-                    <SortablePanel
-                      id={content.id}
-                      content={content.content}
-                    />
-                  </Panel>
-                  {index < panels.length - 1 && (
-                    <PanelResizeHandle className="w-1 bg-gray-300 hover:bg-blue-500 transition-colors duration-200 cursor-ew-resize flex items-center justify-center">
-                      <div className="w-1 h-10 bg-gray-500 rounded-full"></div>
-                    </PanelResizeHandle>
-                  )}
-                </React.Fragment>
-              ))}
-            </PanelGroup>
-          </SortableContext>
+          onDragCancel={handleDragCancel}
+        >
+          {/* 세로로 두 줄(Stack) + 줄 사이 리사이즈 */}
+          <PanelGroup direction="vertical" className="w-full h-full">
+            {/* ---- TOP ROW ---- */}
+            <Panel defaultSize={50} className="h-screen">
+              <SortableRow id="top" items={layout.top} />
+            </Panel>
+            <PanelResizeHandle className="h-1 bg-gray-300 hover:bg-blue-500 transition-colors duration-200 cursor-ns-resize flex items-center justify-center">
+              <div className="h-1 w-10 bg-gray-500 rounded-full" />
+            </PanelResizeHandle>
+            {/* ---- BOTTOM ROW ---- */}
+            <Panel defaultSize={50} className="h-screen">
+              <SortableRow id="bottom" items={layout.bottom} />
+            </Panel>
+          </PanelGroup>
 
           <DragOverlay>
             {draggingPanel ? (
-              <SortablePanel
-                id={draggingPanel.id}
-                content={draggingPanel.content}
-              />
+              <SortablePanel id={draggingPanel.id} content={draggingPanel.content} />
             ) : null}
           </DragOverlay>
         </DndContext>
@@ -146,7 +268,7 @@ function App() {
       <div className="relative z-50">
         <LogBar />
       </div>
-    </main >
+    </main>
   );
 }
 


### PR DESCRIPTION
1. 레이아웃을 위/아래 두 줄(top/bottom) 로 분리
2. 각 줄은 기존처럼 가로 정렬/리사이즈 가능
3. 패널을 같은 줄 내 좌우 재배치 + 줄 사이 상하 이동 모두 지원
4. 줄 자체도 드롭 타겟이므로 빈 줄로의 이동 가능
5. 기존 네 개 패널(Section/ASM/IR/AST) 그대로 사용


## 주요 변경 사항

1. 상태 구조 변경
layout: { top: PanelItem[]; bottom: PanelItem[] }
→ 각 줄 별로 패널 배열을 관리하여 행/열 재배치 로직 단순화.

2. Droppable 컨테이너 도입
DroppableRow(id: 'top' | 'bottom')
→ useDroppable로 줄 자체에 드롭 가능. 줄이 비어 있어도 드롭되는 영역을 확보.

3. 줄 별 SortableContext
SortableRow가 각 줄을 감싸며 horizontalListSortingStrategy 적용.
→ 같은 줄에서는 기존과 동일하게 좌우 재정렬.

4. Drag 종료 처리 분기
findContainer/getItem 유틸로 현재/목표 줄을 식별.
같은 줄이면 arrayMove로 인덱스 변경.
다른 줄이면 from에서 제거 → to에 계산된 위치로 삽입(줄 자체로 드롭 시 맨 뒤).

5. 세로 리사이즈 추가
상/하 두 줄 사이에 PanelResizeHandle 배치 → 행 높이 리사이즈 가능.

6.접근성/키보드 유지
KeyboardSensor + sortableKeyboardCoordinates 유지.
→ 키보드 조작도 기존과 동일하게 동작.